### PR TITLE
Force LF line endings for system/bin/hosts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,4 @@
 *.prop text eol=lf
 *.md text eol=lf
 META-INF/** text eol=lf
+system/bin/hosts text eol=lf


### PR DESCRIPTION
*Preconditions*
* LineageOS 15.1 on Moto G5 Plus (potter)
* Magisk v15.3
* MagiskManager 5.6
* Systemless hosts active

*Problem Description*
Installing v3.6 from [the XDA thread](https://forum.xda-developers.com/apps/magisk/magisk-unified-hosts-adblocker-t3559019) left me with an unusable `hosts` script. It always failed with "syntax error" similar to what's described in [this XDA post](https://forum.xda-developers.com/showpost.php?p=75534177&postcount=1030).
```
'/system/bin/hosts[59]: syntax error: unexpected 'in 
```
Also, the Unified Hosts Manager always complained "module not installed".

*Analysis*
For some reason, in the package provided in the XDA thread, the hosts script has Window line endings, which appears to trip up the bash in my LineageOS 15.1 (verified with multiple terminals).

*Workaround*
I've converted the file from the v3.6 zip with `dos2unix` and repackaged it into the zip as v3.6a and flashed it in TWRP.
Now the Unified Hosts Manager recognized it and I could install the selected lists. It works!

*Solution*
Make sure the hosts script is always checked out with Linux line endings.